### PR TITLE
Version 0.3.1

### DIFF
--- a/R/effect_plots.R
+++ b/R/effect_plots.R
@@ -71,8 +71,7 @@ create_feature_plot_list <- function(object, plot_fun) {
       cat(paste0("Iteration ", i, "/", nrow(object), "\n"))
     }
     fname <- featureNames(object)[i]
-    p <- plot_fun(object, fname) +
-      theme(plot.title = ggtext::element_textbox_simple())
+    p <- plot_fun(object, fname)
     plot_list[[i]] <- p
   }
 
@@ -101,6 +100,7 @@ create_feature_plot_list <- function(object, plot_fun) {
 #' @param text_base_size integer, base size for text in figures
 #' @param line_width numeric, width of the lines
 #' @param mean_line_width numeric, width of the mean line
+#' @param title_line_length integer, maximum length of the title line in characters, passed to stringr::str_wrap
 #' @param theme a ggplot theme to be added to the plot
 #' @param ... other arguments to graphic device functions, like width and height
 #'
@@ -132,6 +132,7 @@ save_subject_line_plots <- function(object,
                                     text_base_size = 14,
                                     line_width = 0.3,
                                     mean_line_width = 1.2,
+                                    title_line_length = 40,
                                     theme = theme_bw(base_size = text_base_size),
                                     ...) {
   if (is.na(x)) {
@@ -151,12 +152,12 @@ save_subject_line_plots <- function(object,
         geom_line(aes(group = .data[[id]]),
           color = "grey20",
           alpha = 0.35,
-          linewidth = line_width
+          size = line_width
         ) +
         stat_summary(aes(group = 1),
           fun.data = "mean_se",
           geom = "line",
-          linewidth = mean_line_width,
+          size = mean_line_width,
           color = color_scale$palette(1)[1]
         )
     } else {
@@ -183,12 +184,10 @@ save_subject_line_plots <- function(object,
       p <- p +
       theme +
       labs(
-        title = fData(object)[fname, title],
+        title = stringr::str_wrap(fData(object)[fname, title], title_line_length),
         subtitle = fData(object)[fname, subtitle],
         y = "Abundance"
       )
-    # Split long titles to multiple rows
-    p <- p + theme(plot.title = ggtext::element_textbox_simple())
     p
   }
 
@@ -225,6 +224,7 @@ save_subject_line_plots <- function(object,
 #' @param box_width numeric, width of the boxes
 #' @param line_width numeric, width of the lines
 #' @param point_size numeric, size of the mean points
+#' @param title_line_length integer, maximum length of the title line in characters, passed to stringr::str_wrap
 #' @param theme a ggplot theme to be added to the plot
 #' @param ... other arguments to graphic device functions, like width and height
 #'
@@ -263,6 +263,7 @@ save_group_boxplots <- function(object,
                                 box_width = 0.8,
                                 line_width = 0.5,
                                 point_size = 3,
+                                title_line_length = 40,
                                 theme = theme_bw(base_size = text_base_size),
                                 ...) {
   boxplot_fun <- function(object, fname) {
@@ -280,15 +281,13 @@ save_group_boxplots <- function(object,
       color_scale +
       theme +
       labs(
-        title = fData(object)[fname, title],
+        title = stringr::str_wrap(fData(object)[fname, title], title_line_length),
         subtitle = fData(object)[fname, subtitle],
         y = "Abundance"
       )
     if (x == color) {
       p <- p + guides(color = "none")
     }
-    # Split long titles to multiple rows
-    p <- p + theme(plot.title = ggtext::element_textbox_simple())
     p
   }
 
@@ -326,6 +325,7 @@ save_group_boxplots <- function(object,
 #' @param text_base_size integer, base size for text in figures
 #' @param cex numeric, scaling for adjusting point spacing
 #' @param size numeric, size of points
+#' @param title_line_length integer, maximum length of the title line in characters, passed to stringr::str_wrap
 #' @param theme a ggplot theme to be added to the plot
 #' @param ... other arguments to graphic device functions, like width and height
 #'
@@ -364,6 +364,7 @@ save_beeswarm_plots <- function(object,
                                 text_base_size = 14,
                                 cex = 2,
                                 size = 2,
+                                title_line_length = 40,
                                 theme = theme_bw(base_size = text_base_size),
                                 ...) {
   beeswarm_fun <- function(object, fname) {
@@ -380,15 +381,13 @@ save_beeswarm_plots <- function(object,
       color_scale +
       theme +
       labs(
-        title = fData(object)[fname, title],
+        title = stringr::str_wrap(fData(object)[fname, title], title_line_length),
         subtitle = fData(object)[fname, subtitle],
         y = "Abundance"
       )
     if (x == color) {
       p <- p + guides(color = "none")
     }
-    # Split long titles to multiple rows
-    p <- p + theme(plot.title = ggtext::element_textbox_simple())
     p
   }
 
@@ -426,6 +425,7 @@ save_beeswarm_plots <- function(object,
 #' @param shape_scale the shape scale as returned by a ggplot function
 #' @param text_base_size integer, base size for text in figures
 #' @param point_size numeric, size of the points
+#' @param title_line_length integer, maximum length of the title line in characters, passed to stringr::str_wrap
 #' @param theme a ggplot theme to be added to the plot
 #' @param ... other arguments to graphic device functions, like width and height
 #'
@@ -460,6 +460,7 @@ save_scatter_plots <- function(object,
                                shape_scale = getOption("notame.shape_scale"),
                                text_base_size = 14,
                                point_size = 2,
+                               title_line_length = 40,
                                theme = theme_bw(base_size = text_base_size),
                                ...) {
   scatter_fun <- function(object, fname) {
@@ -478,12 +479,10 @@ save_scatter_plots <- function(object,
     ) +
       theme +
       labs(
-        title = fData(object)[fname, title],
+        title = stringr::str_wrap(fData(object)[fname, title], title_line_length),
         subtitle = fData(object)[fname, subtitle],
         y = "Abundance"
       )
-    # Split long titles to multiple rows
-    p <- p + theme(plot.title = ggtext::element_textbox_simple())
     p
   }
   object <- drop_flagged(object, all_features)
@@ -524,6 +523,7 @@ save_scatter_plots <- function(object,
 #' @param text_base_size integer, base size for text in figures
 #' @param line_width numeric, width of the lines
 #' @param point_size numeric, size of the points
+#' @param title_line_length integer, maximum length of the title line in characters, passed to stringr::str_wrap
 #' @param theme a ggplot theme to be added to the plot
 #' @param ... other arguments to graphic device functions, like width and height
 #'
@@ -563,6 +563,7 @@ save_group_lineplots <- function(object,
                                  text_base_size = 14,
                                  line_width = 0.5,
                                  point_size = 4,
+                                 title_line_length = 40,
                                  theme = theme_bw(base_size = text_base_size),
                                  ...) {
   if (is.na(group)) {
@@ -609,15 +610,13 @@ save_group_lineplots <- function(object,
       color_scale +
       theme +
       labs(
-        title = fData(object)[fname, title],
+        title = stringr::str_wrap(fData(object)[fname, title], title_line_length),
         subtitle = fData(object)[fname, subtitle],
         y = "Abundance"
       )
     if (x == group) {
       p <- p + guides(color = "none")
     }
-    # Split long titles to multiple rows
-    p <- p + theme(plot.title = ggtext::element_textbox_simple())
     p
   }
 

--- a/R/scatter.R
+++ b/R/scatter.R
@@ -186,13 +186,10 @@ scatter_plot <- function(data, x, y, color, shape, label = NULL, density = FALSE
       }
     }
   }
-  #
-  if (!is.null(color)) {
-    color <- data[[color]]
-  }
+
   p <- ggplot(data, aes(
     x = .data[[x]], y = .data[[y]],
-    color = color
+    color = if (!is.null(color)) .data[[color]]
   )) +
     color_scale +
     labs(
@@ -240,7 +237,13 @@ scatter_plot <- function(data, x, y, color, shape, label = NULL, density = FALSE
       )
     }
     p <- p +
-      ggrepel::geom_text_repel(aes(label = .data[[label]]), size = label_text_size)
+      ggrepel::geom_text_repel(
+        mapping = aes(
+          label = .data[[label]]
+        ),
+        size = label_text_size
+      ) +
+      guides(color = guide_legend(override.aes = aes(label = ""))) # Removes "a" from the legend (ggrepel adds it by default)
   }
 
   # Add density plots to top and right
@@ -720,11 +723,14 @@ volcano_plotter <- function(data, x, p, p_fdr, color, p_breaks, fdr_limit,
     warning("All the p-values are larger than the p-value breaks supplied. Consider using larger p_breaks for plotting")
   }
 
-  pl <- ggplot(data, aes(x = .data[[x]], y = .data[[p]], color = .data[[color]])) +
+  pl <- ggplot(data, aes(
+    x = .data[[x]], y = .data[[p]],
+    color = if (!is.null(color)) .data[[color]]
+  )) +
     geom_point(...) +
     color_scale +
     theme_bw(base_size = text_base_size) +
-    labs(title = title, subtitle = subtitle) +
+    labs(title = title, subtitle = subtitle, color = color) +
     theme(
       panel.grid.minor.y = element_blank(), # only show the specified p-values, which might be unevenly spaced
       axis.ticks.y = element_blank()
@@ -830,14 +836,14 @@ volcano_plotter <- function(data, x, p, p_fdr, color, p_breaks, fdr_limit,
 #' lm_data <- dplyr::left_join(fData(merged_sample), lm_results)
 #' # Traditional Manhattan plot from data frame
 #' manhattan_plot(lm_data,
-#'   x = "Average.Mz",
+#'   x = "Average_Mz",
 #'   p = "GroupB_P", p_fdr = "GroupB_P_FDR",
 #'   fdr_limit = 0.1
 #' )
 #' # Directed Manhattan plot from MetaboSet
 #' with_results <- join_fData(merged_sample, lm_results)
 #' manhattan_plot(with_results,
-#'   x = "Average.Mz", effect = "GroupB_Estimate",
+#'   x = "Average_Mz", effect = "GroupB_Estimate",
 #'   p = "GroupB_P", p_fdr = "GroupB_P_FDR",
 #'   fdr_limit = 0.1
 #' )
@@ -918,7 +924,10 @@ manhattan_plotter <- function(data, x, p, effect, p_fdr, color,
     p_breaks <- sort(p_breaks)
   }
 
-  pl <- ggplot(data, aes(x = .data[[x]], y = .data[["y"]], color = .data[[color]])) +
+  pl <- ggplot(data, aes(
+    x = .data[[x]], y = .data[["y"]],
+    color = if (!is.null(color)) .data[[color]]
+  )) +
     geom_point(...) +
     color_scale +
     theme_bw() +
@@ -927,7 +936,7 @@ manhattan_plotter <- function(data, x, p, effect, p_fdr, color,
       axis.ticks.y = element_blank()
     ) +
     geom_hline(yintercept = 0, color = "grey") +
-    labs(title = title, subtitle = subtitle, y = "p-value")
+    labs(title = title, subtitle = subtitle, y = "p-value", color = color)
 
 
   if (!is.null(p_fdr)) {
@@ -1058,7 +1067,7 @@ mz_rt_plotter <- function(x, p_col, p_limit, mz_col, rt_col, color, title, subti
 
   p <- ggplot(x, aes(
     x = .data[[rt_col]], y = .data[[mz_col]], size = .data[[p_col]],
-    color = .data[[color]]
+    color = if (!is.null(color)) .data[[color]]
   )) +
     geom_point(alpha = 0.6) +
     scale_size_continuous(
@@ -1068,7 +1077,7 @@ mz_rt_plotter <- function(x, p_col, p_limit, mz_col, rt_col, color, title, subti
     theme_bw() +
     color_scale +
     labs(
-      title = title, subtitle = subtitle,
+      title = title, subtitle = subtitle, color = color,
       x = "Retention time", y = "Mass-to-charge ratio", size = "p-value"
     ) +
     # Scales for m/z and rt

--- a/R/transformations.R
+++ b/R/transformations.R
@@ -44,14 +44,14 @@ mark_nas <- function(object, value) {
 #'
 #' @examples
 #' # Spectra before fixing
-#' fData(merged_sample)$MS.MS.spectrum[!is.na(fData(merged_sample)$MS.MS.spectrum)]
+#' fData(merged_sample)$MS_MS_spectrum[!is.na(fData(merged_sample)$MS_MS_spectrum)]
 #' # Fixing spectra with default settings
 #' fixed_MSMS_peaks <- fix_MSMS(merged_sample)
 #' # Spectra after fixing
 #' fData(fixed_MSMS_peaks)$MS_MS_Spectrum_clean[!is.na(fData(fixed_MSMS_peaks)$MS_MS_Spectrum_clean)]
 #'
 #' @export
-fix_MSMS <- function(object, ms_ms_spectrum_col = "MS.MS.spectrum", # nolint: object_name_linter.
+fix_MSMS <- function(object, ms_ms_spectrum_col = "MS_MS_spectrum", # nolint: object_name_linter.
                      peak_num = 10,
                      min_abund = 5,
                      deci_num = 3) {

--- a/man/fix_MSMS.Rd
+++ b/man/fix_MSMS.Rd
@@ -6,7 +6,7 @@
 \usage{
 fix_MSMS(
   object,
-  ms_ms_spectrum_col = "MS.MS.spectrum",
+  ms_ms_spectrum_col = "MS_MS_spectrum",
   peak_num = 10,
   min_abund = 5,
   deci_num = 3
@@ -41,7 +41,7 @@ m/z  (Abundance)
 }
 \examples{
 # Spectra before fixing
-fData(merged_sample)$MS.MS.spectrum[!is.na(fData(merged_sample)$MS.MS.spectrum)]
+fData(merged_sample)$MS_MS_spectrum[!is.na(fData(merged_sample)$MS_MS_spectrum)]
 # Fixing spectra with default settings
 fixed_MSMS_peaks <- fix_MSMS(merged_sample)
 # Spectra after fixing

--- a/man/manhattan_plot.Rd
+++ b/man/manhattan_plot.Rd
@@ -62,14 +62,14 @@ lm_results <- perform_lm(drop_qcs(merged_sample), formula_char = "Feature ~ Grou
 lm_data <- dplyr::left_join(fData(merged_sample), lm_results)
 # Traditional Manhattan plot from data frame
 manhattan_plot(lm_data,
-  x = "Average.Mz",
+  x = "Average_Mz",
   p = "GroupB_P", p_fdr = "GroupB_P_FDR",
   fdr_limit = 0.1
 )
 # Directed Manhattan plot from MetaboSet
 with_results <- join_fData(merged_sample, lm_results)
 manhattan_plot(with_results,
-  x = "Average.Mz", effect = "GroupB_Estimate",
+  x = "Average_Mz", effect = "GroupB_Estimate",
   p = "GroupB_P", p_fdr = "GroupB_P_FDR",
   fdr_limit = 0.1
 )

--- a/man/save_beeswarm_plots.Rd
+++ b/man/save_beeswarm_plots.Rd
@@ -19,6 +19,7 @@ save_beeswarm_plots(
   text_base_size = 14,
   cex = 2,
   size = 2,
+  title_line_length = 40,
   theme = theme_bw(base_size = text_base_size),
   ...
 )
@@ -49,6 +50,8 @@ Set to NULL for no title/subtitle, this creates running numbered filenames}
 \item{cex}{numeric, scaling for adjusting point spacing}
 
 \item{size}{numeric, size of points}
+
+\item{title_line_length}{integer, maximum length of the title line in characters, passed to stringr::str_wrap}
 
 \item{theme}{a ggplot theme to be added to the plot}
 

--- a/man/save_group_boxplots.Rd
+++ b/man/save_group_boxplots.Rd
@@ -19,6 +19,7 @@ save_group_boxplots(
   box_width = 0.8,
   line_width = 0.5,
   point_size = 3,
+  title_line_length = 40,
   theme = theme_bw(base_size = text_base_size),
   ...
 )
@@ -51,6 +52,8 @@ Set to NULL for no title/subtitle, this creates running numbered filenames}
 \item{line_width}{numeric, width of the lines}
 
 \item{point_size}{numeric, size of the mean points}
+
+\item{title_line_length}{integer, maximum length of the title line in characters, passed to stringr::str_wrap}
 
 \item{theme}{a ggplot theme to be added to the plot}
 

--- a/man/save_group_lineplots.Rd
+++ b/man/save_group_lineplots.Rd
@@ -23,6 +23,7 @@ save_group_lineplots(
   text_base_size = 14,
   line_width = 0.5,
   point_size = 4,
+  title_line_length = 40,
   theme = theme_bw(base_size = text_base_size),
   ...
 )
@@ -59,6 +60,8 @@ Set to NULL for no title/subtitle, this creates running numbered filenames}
 \item{line_width}{numeric, width of the lines}
 
 \item{point_size}{numeric, size of the points}
+
+\item{title_line_length}{integer, maximum length of the title line in characters, passed to stringr::str_wrap}
 
 \item{theme}{a ggplot theme to be added to the plot}
 

--- a/man/save_scatter_plots.Rd
+++ b/man/save_scatter_plots.Rd
@@ -19,6 +19,7 @@ save_scatter_plots(
   shape_scale = getOption("notame.shape_scale"),
   text_base_size = 14,
   point_size = 2,
+  title_line_length = 40,
   theme = theme_bw(base_size = text_base_size),
   ...
 )
@@ -50,6 +51,8 @@ Set to NULL for no title/subtitle, this creates running numbered filenames}
 \item{text_base_size}{integer, base size for text in figures}
 
 \item{point_size}{numeric, size of the points}
+
+\item{title_line_length}{integer, maximum length of the title line in characters, passed to stringr::str_wrap}
 
 \item{theme}{a ggplot theme to be added to the plot}
 

--- a/man/save_subject_line_plots.Rd
+++ b/man/save_subject_line_plots.Rd
@@ -20,6 +20,7 @@ save_subject_line_plots(
   text_base_size = 14,
   line_width = 0.3,
   mean_line_width = 1.2,
+  title_line_length = 40,
   theme = theme_bw(base_size = text_base_size),
   ...
 )
@@ -54,6 +55,8 @@ Set to NULL for no title/subtitle, this creates running numbered filenames}
 \item{line_width}{numeric, width of the lines}
 
 \item{mean_line_width}{numeric, width of the mean line}
+
+\item{title_line_length}{integer, maximum length of the title line in characters, passed to stringr::str_wrap}
 
 \item{theme}{a ggplot theme to be added to the plot}
 


### PR DESCRIPTION
This version contains couple bug fixes for version 0.3.0:
- Long titles are now handled with `stringr::str_wrap` instead of  `ggtext::element_textbox_simple`
- Fixed a bug with color legends in scatter plots
- Updated outdated examples 